### PR TITLE
feat: add bypass calls toggle

### DIFF
--- a/module/system/bin/zapret
+++ b/module/system/bin/zapret
@@ -12,6 +12,7 @@ CUSTOMLINKIPSETV6=$(cat "$MODPATH/config/ipset-v6-link" 2>/dev/null || echo "htt
 CUSTOMLINKREESTR=$(cat "$MODPATH/config/reestr-link" 2>/dev/null || echo "https://raw.githubusercontent.com/sevcator/zapret-lists/refs/heads/main/reestr_filtered.txt")
 IPV6ENABLE=$(cat "$MODPATH/config/ipv6-enable" 2>/dev/null || echo "0")
 NETWORKTWEAKS=$(cat "$MODPATH/config/network-tweaks" 2>/dev/null || echo "0")
+BYPASSCALLS=$(cat "$MODPATH/config/bypass-calls" 2>/dev/null || echo "0")
 
 command_info() {
     echo "--- Zapret Module for Magisk ---"
@@ -35,6 +36,11 @@ command_info() {
         echo "! Network tweaks enabled"
     else
         echo "! Network tweaks disabled"
+    fi
+    if [ "$BYPASSCALLS" = "1" ]; then
+        echo "! Bypass calls enabled"
+    else
+        echo "! Bypass calls disabled"
     fi
     echo "------ Available commands ------"
     echo "  * Service control"
@@ -94,6 +100,7 @@ setup() {
     CLOAKINGUPDATE="0"
     BLOCKEDUPDATE="0"
     UPDATEONSTART="0"
+    BYPASSCALLS="0"
     echo "! If the selection is anything other than \"Y\" or \"Yes\", it is considered a negative choice"
 
     echo -n "- Enable update on start? "
@@ -108,10 +115,16 @@ setup() {
         y|yes) echo "- Enabled"; IPV6ENABLE="1" ;;
     esac
     
-    echo -n "- Enable Network Traces? "
+    echo -n "- Enable Network Tweaks? "
     read response
     case "$(echo "$response" | tr A-Z a-z)" in
         y|yes) echo "- Enabled"; NETWORKTWEAKS="1" ;;
+    esac
+
+    echo -n "- Enable bypass calls? "
+    read response
+    case "$(echo "$response" | tr A-Z a-z)" in
+        y|yes) echo "- Enabled"; BYPASSCALLS="1" ;;
     esac
     
     echo -n "- Enable DNSCrypt? "
@@ -220,6 +233,7 @@ setup() {
     echo "$CUSTOMLINKREESTR" > "$MODPATH/config/reestr-link"
     echo "$IPV6ENABLE" > "$MODPATH/config/ipv6-enable"
     echo "$NETWORKTWEAKS" > "$MODPATH/config/network-tweaks"
+    echo "$BYPASSCALLS" > "$MODPATH/config/bypass-calls"
     
     echo "- Done! Changes will apply on next start"
     return 0

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -994,6 +994,16 @@
       </h2>
 <div class="settings">
 <div class="setting-item">
+<label data-i18n="bypass_calls">
+         Включить обход звонков
+        </label>
+<label class="switch">
+<input id="toggle-bypass-calls" type="checkbox"/>
+<span class="slider">
+</span>
+</label>
+</div>
+<div class="setting-item">
 <label data-i18n="active_strategy">
          Активная стратегия
         </label>
@@ -1248,6 +1258,7 @@
                 "btn_save": "Сохранить",
                 "settings_title": "Настройки",
                 "module_settings_title": "Параметры модуля",
+                "bypass_calls": "Включить обход звонков",
                 "active_strategy": "Стратегия",
                 "dnscrypt_proxy": "DNSCrypt Proxy",
                 "dnscrypt_rules_refresh": "Обновление правил",
@@ -1294,6 +1305,7 @@
                 "btn_save": "Save",
                 "settings_title": "Settings",
                 "module_settings_title": "Module Parameters",
+                "bypass_calls": "Enable bypass calls",
                 "active_strategy": "Strategy",
                 "dnscrypt_proxy": "DNSCrypt Proxy",
                 "dnscrypt_rules_refresh": "Refresh rules",  
@@ -1582,6 +1594,7 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                         const updateOnStart = await run(`cat ${MODPATH}/config/update-on-start 2>/dev/null || true`);
                         const cloakingUpdate = await run(`cat ${MODPATH}/config/dnscrypt-cloaking-rules-update 2>/dev/null || true`);
                         const blockedNamesUpdate = await run(`cat ${MODPATH}/config/dnscrypt-blocked-names-update 2>/dev/null || true`);
+                        const bypassCalls = await run(`cat ${MODPATH}/config/bypass-calls 2>/dev/null || true`);
                         const ipv6Enable = await run(`cat ${MODPATH}/config/ipv6-enable 2>/dev/null || true`);
                         const networkTweaks = await run(`cat ${MODPATH}/config/network-tweaks 2>/dev/null || true`);
                         
@@ -1641,6 +1654,7 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                         toggleUpdateOnStart.checked = updateOnStart === '1' || updateOnStart === '';
                         toggleCloakingUpdate.checked = cloakingUpdate === '1';
                         toggleBlockedNamesUpdate.checked = blockedNamesUpdate === '1';
+                        document.getElementById('toggle-bypass-calls').checked = bypassCalls === '1';
                         document.getElementById('toggle-ipv6').checked = ipv6Enable === '1';
                         document.getElementById('toggle-network-tweaks').checked = networkTweaks === '1';
                         
@@ -1752,6 +1766,7 @@ btnPrimary.addEventListener('click', async () => {
                 setupToggle(toggleUpdateOnStart, 'update-on-start');
                 setupToggle(toggleCloakingUpdate, 'dnscrypt-cloaking-rules-update');
                 setupToggle(toggleBlockedNamesUpdate, 'dnscrypt-blocked-names-update');
+                setupToggle(document.getElementById('toggle-bypass-calls'), 'bypass-calls');
                 setupToggle(document.getElementById('toggle-ipv6'), 'ipv6-enable');
                 setupToggle(document.getElementById('toggle-network-tweaks'), 'network-tweaks');
 


### PR DESCRIPTION
## Summary
- add bypass calls toggle to web UI and CLI setup
- store bypass call preference in config
- rename network traces prompt to network tweaks

## Testing
- `bash -n module/system/bin/zapret`
- `shellcheck module/system/bin/zapret` *(fails: command not found; `apt-get update` 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac76dcc1f483319a5e3daeab0be090