### PR TITLE
Fix IPv6 restore loop and clean up scripts

### DIFF
--- a/module/action.sh
+++ b/module/action.sh
@@ -1,5 +1,5 @@
 MODPATH="/data/adb/modules/zapret"
-echo "! Please wait, this action take a some time"
+echo "! Please wait, this action takes some time"
 if pgrep -f "nfqws" >/dev/null 2>&1; then
     sh "$MODPATH/uninstall.sh" > /dev/null 2>&1
     echo "- Service stopped"

--- a/module/uninstall.sh
+++ b/module/uninstall.sh
@@ -26,10 +26,8 @@ for pid in $PIDS_FROM_DIR; do
     fi
 done
 for iface in all default lo; do
-    resetprop net.ipv6.conf.all.disable_ipv6 0
-    resetprop net.ipv6.conf.default.disable_ipv6 0
-    resetprop net.ipv6.conf.all.accept_redirects 1
-    resetprop net.ipv6.conf.default.accept_redirects 1
+    resetprop net.ipv6.conf.$iface.disable_ipv6 0
+    resetprop net.ipv6.conf.$iface.accept_redirects 1
 done
 sysctl net.netfilter.nf_conntrack_tcp_be_liberal=0 > /dev/null 2>&1
 sysctl net.netfilter.nf_conntrack_checksum=1 > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- fix IPv6 restore loop to use interface variable
- clean up action script messaging
- drop unnecessary edits to service, update, and customize scripts

## Testing
- `bash -n module/action.sh`
- `bash -n module/service.sh`
- `bash -n module/uninstall.sh`
- `bash -n module/update.sh`
- `bash -n module/customize.sh`


------
https://chatgpt.com/codex/tasks/task_e_68afc65847148331b37d11158ba19aa7