### PR TITLE
fix: add shebang and tidy zapret script

### DIFF
--- a/module/zapret/zapret.sh
+++ b/module/zapret/zapret.sh
@@ -1,9 +1,11 @@
+#!/system/bin/sh
+
 MODPATH="/data/adb/modules/zapret"
-CURRENTSTRATEGY=$(cat $MODPATH/config/current-strategy)
+CURRENTSTRATEGY=$(cat "$MODPATH/config/current-strategy")
 . "$MODPATH/strategy/$CURRENTSTRATEGY.sh"
 sysctl net.netfilter.nf_conntrack_tcp_be_liberal=1 > /dev/null 2>&1
 if [[ "$config" == *badsum* ]]; then
-    sysctl net.netfilter.nf_conntrack_checksum=0 > /dev/null > /dev/null 2>&1
+    sysctl net.netfilter.nf_conntrack_checksum=0 > /dev/null 2>&1
 fi
 . "$MODPATH/zapret/nfqws.sh" &
 tcp_ports="$(echo $config | grep -oE 'filter-tcp=[0-9,-]+' | sed -e 's/.*=//g' -e 's/,/\n/g' -e 's/ /,/g' | sort -un)";


### PR DESCRIPTION
## Summary
- add missing shebang to zapret script
- remove redundant output redirection

## Testing
- `sh -n module/zapret/zapret.sh`


------
https://chatgpt.com/codex/tasks/task_e_68afc926943c8331b9b4796d9f15c84e