### PR TITLE
Fix dnscrypt script for POSIX sh

### DIFF
--- a/module/dnscrypt/dnscrypt.sh
+++ b/module/dnscrypt/dnscrypt.sh
@@ -5,8 +5,7 @@ REFRESH=$(cat "$MODPATH/config/dnscrypt-rules-fix" 2>/dev/null || echo "0")
 
 setup() {
   echo 1 >/proc/sys/net/ipv4/conf/all/route_localnet
-  CHAINS=(PREROUTING OUTPUT FORWARD)
-  for chain in "${CHAINS[@]}"; do
+  for chain in PREROUTING OUTPUT FORWARD; do
     for proto in udp tcp; do
       iptables -t nat -C "$chain" -p $proto --dport 53 -j DNAT --to-destination 127.0.0.1:5253 2>/dev/null || iptables -t nat -A "$chain" -p $proto --dport 53 -j DNAT --to-destination 127.0.0.1:5253
       ip6tables -t nat -C "$chain" -p $proto --dport 53 -j REDIRECT --to-ports 5253 2>/dev/null || ip6tables -t nat -A "$chain" -p $proto --dport 53 -j REDIRECT --to-ports 5253
@@ -29,7 +28,7 @@ start_bg(){
 start_fg(){
   [ -x "$MODPATH/dnscrypt/make-unkillable.sh" ] && nohup sh "$MODPATH/dnscrypt/make-unkillable.sh" >/dev/null 2>&1 &
   [ -x "$MODPATH/dnscrypt/dnscrypt-proxy" ] || { echo "dnscrypt-proxy not found" >&2; exit 1; }
-  exec "$MODPATH/dnscrypt/dnscrypt-proxy" >/dev/null 2>&1
+  "$MODPATH/dnscrypt/dnscrypt-proxy" >/dev/null 2>&1
 }
 
 if [ "$REFRESH" = "1" ]; then


### PR DESCRIPTION
## Summary
- iterate NAT chains directly without Bash arrays
- restore original iptables rule formatting
- allow foreground mode to loop by removing `exec`

## Testing
- `sh -n module/dnscrypt/dnscrypt.sh`
- `for f in $(find module -name '*.sh'); do echo checking $f; sh -n "$f" || echo "syntax error in $f"; done`


------
https://chatgpt.com/codex/tasks/task_e_68afca0c1dac83319870711513af3bc5