### PR TITLE
Ensure shell scripts use portable syntax

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -53,7 +53,7 @@ if [ "$NETWORKTWEAKS" = "1" ]; then
     sysctl -w net.core.xfrm_larval_drop=1
 fi
 boot_wait() {
-    while [[ -z $(getprop sys.boot_completed) ]]; do sleep 2; done
+    while [ -z "$(getprop sys.boot_completed)" ]; do sleep 2; done
 }
 boot_wait
 sleep 2


### PR DESCRIPTION
## Summary
- Replace bash-specific `[[` tests with portable alternatives in service and zapret scripts
- Simplify port range handling using `case`

## Testing
- `find module -name '*.sh' -exec bash -n {} \;`
- `apt-get update` (failed: 403  Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68afccdec6bc8331a4c908dc13b498eb