### PR TITLE
Handle empty cloaking rules file

### DIFF
--- a/module/dnscrypt/custom-cloaking-rules.sh
+++ b/module/dnscrypt/custom-cloaking-rules.sh
@@ -7,6 +7,7 @@ CUSTOM_RULES=$MODPATH/dnscrypt/custom-cloaking-rules.txt
 
 ensure_newline() {
   [ -f "$1" ] || return
+  [ -s "$1" ] || return
   [ "$(tail -c1 "$1")" = "" ] && return
   printf "\n" >> "$1"
 }


### PR DESCRIPTION
## Summary
- guard against empty custom cloaking rules to avoid tail failure

## Testing
- `sh -n module/dnscrypt/custom-cloaking-rules.sh`


------
https://chatgpt.com/codex/tasks/task_e_68afce12cf788331a24e50cebdaab0db