### PR TITLE
Point repo links to zapret-pocket and rebrand to Zapret Pocket

### DIFF
--- a/.github/workflows/build_module.yml
+++ b/.github/workflows/build_module.yml
@@ -1,4 +1,4 @@
-name: Build Zapret Module
+name: Build Zapret Pocket
 run-name: ${{ startsWith(github.ref, 'refs/tags/') && format('Release {0}', github.ref_name) || null }}
 
 on:
@@ -105,7 +105,7 @@ jobs:
           path: dnscrypt-proxy/dnscrypt-proxy/binaries/*
 
   build-module:
-    name: Magisk Module
+    name: Zapret Pocket Module
     runs-on: ubuntu-latest
     needs: [build-zapret, build-dnscrypt]
     steps:
@@ -158,7 +158,7 @@ jobs:
           name: dnscrypt-proxy
           path: module/dnscrypt
 
-      - name: Build Magisk Module
+      - name: Build Module
         run: |
           version=${{ github.ref_name }}
           version_code=$(echo "${version}" | sed 's/[^0-9]//g')
@@ -188,7 +188,7 @@ jobs:
           echo "updateJson=https://raw.githubusercontent.com/${{ github.repository }}/refs/heads/main/update.json" >> module.prop
 
           cd ..
-          7z a zapret-Magisk.zip ./module/*
+          7z a zapret-pocket.zip ./module/*
 
       - name: Set up Git
         run: |
@@ -200,7 +200,7 @@ jobs:
           echo '{
             "version": "${{ env.version }}",
             "versionCode": "${{ env.versionCode }}",
-            "zipUrl": "https://github.com/${{ github.repository }}/releases/download/${{ env.version }}/zapret-Magisk.zip",
+            "zipUrl": "https://github.com/${{ github.repository }}/releases/download/${{ env.version }}/zapret-pocket.zip",
             "changelog": "https://raw.githubusercontent.com/${{ github.repository }}/main/CHANGELOG.md"
           }' > update.json
           git add update.json
@@ -214,13 +214,13 @@ jobs:
 
       - name: Calculate SHA-256 checksum
         id: sha256
-        run: echo "SHA256=$(sha256sum zapret-Magisk.zip | awk '{ print $1 }')" >> $GITHUB_ENV
+        run: echo "SHA256=$(sha256sum zapret-pocket.zip | awk '{ print $1 }')" >> $GITHUB_ENV
           
       - name: Upload Module Zip
         uses: actions/upload-artifact@v4
         with:
-          name: zapret-Magisk
-          path: zapret-Magisk.zip
+          name: zapret-pocket
+          path: zapret-pocket.zip
           if-no-files-found: error
 
       - name: Upload to Release
@@ -231,12 +231,12 @@ jobs:
           fail_on_unmatched_files: true
           draft: false
           files: |
-            zapret-Magisk.zip
+            zapret-pocket.zip
 
       - name: Send to Telegram
         run: |
           curl -X POST \
-            -F document=@"zapret-Magisk.zip" \
+            -F document=@"zapret-pocket.zip" \
             -F chat_id="${TELEGRAM_CHAT_ID}" \
             -F caption="$(echo -e "🔔 <b>New release:</b> <a href=\"https://github.com/$GITHUB_REPOSITORY/releases/tag/$VERSION\">$VERSION</a>\n🔑 <b>SHA256:</b> $SHA256")" \
             -F parse_mode=HTML \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 [📢 Telegram Channel](https://t.me/sevcator/921)
 
-[📁 Repository](https://github.com/sevcator/zapret-magisk/)
+[📁 Repository](https://github.com/sevcator/zapret-pocket/)
 
-[📖 Report Issues](https://github.com/sevcator/zapret-magisk/issues)
+[📖 Report Issues](https://github.com/sevcator/zapret-pocket/issues)
 
 [💸 Donate](https://t.me/sevcator/909)
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 > [!CAUTION]
-> This notice is governed by the applicable law in the user’s jurisdiction. The author does not accept any responsibility for legal consequences arising from the use of this software in violation of local laws. See the [DISCLAMER](https://github.com/sevcator/zapret-magisk/blob/main/DISCLAMER) for details.
+> This notice is governed by the applicable law in the user’s jurisdiction. The author does not accept any responsibility for legal consequences arising from the use of this software in violation of local laws. See the [DISCLAMER](https://github.com/sevcator/zapret-pocket/blob/main/DISCLAMER) for details.
 
 <p align="center">
-  <img src="https://github.com/sevcator/zapret-magisk/blob/main/icon.png?raw=true" 
+  <img src="https://github.com/sevcator/zapret-pocket/blob/main/icon.png?raw=true"
        alt="zapret" 
        width="128" 
        height="128">
 </p>
 
-<h1 align="center">zapret for Magisk</h1>
+<h1 align="center">Zapret Pocket</h1>
 
 <div align="center">
   <a href="https://t.me/sevcator/921">📢 Telegram Channel</a> | 
@@ -16,7 +16,7 @@
 </div>
 
 # License
-This project is licensed. See the [LICENSE](https://github.com/sevcator/zapret-magisk/blob/main/LICENSE) file for details.
+This project is licensed. See the [LICENSE](https://github.com/sevcator/zapret-pocket/blob/main/LICENSE) file for details.
 
 # Contributing
 Feel free to contribute to this project by submitting issues or pull requests.

--- a/module/dnscrypt/blocked-names.txt
+++ b/module/dnscrypt/blocked-names.txt
@@ -2,7 +2,7 @@
 #        Blocklist        #
 ###########################
 
-# For https://github.com/sevcator/zapret-magisk <3
+# For https://github.com/sevcator/zapret-pocket <3
 
 ## Rules for name-based query blocking, one per line
 ##

--- a/module/dnscrypt/cloaking-rules.txt
+++ b/module/dnscrypt/cloaking-rules.txt
@@ -2,7 +2,7 @@
 #        Cloaking rules        #
 ################################
 
-# For https://github.com/sevcator/zapret-magisk <3
+# For https://github.com/sevcator/zapret-pocket <3
 
 # Multiple IP entries for the same name are supported.
 # In the following example, the same name maps both to IPv4 and IPv6 addresses:

--- a/module/dnscrypt/dnscrypt-proxy.toml
+++ b/module/dnscrypt/dnscrypt-proxy.toml
@@ -1,5 +1,5 @@
 ########################################################
-#         For github.com/sevcator/zapret-magisk        #
+#         For github.com/sevcator/zapret-pocket       #
 ########################################################
 
 listen_addresses = ['127.0.0.1:5253']

--- a/module/system/bin/zapret
+++ b/module/system/bin/zapret
@@ -15,7 +15,7 @@ NETWORKTWEAKS=$(cat "$MODPATH/config/network-tweaks" 2>/dev/null || echo "0")
 BYPASSCALLS=$(cat "$MODPATH/config/bypass-calls" 2>/dev/null || echo "0")
 
 command_info() {
-    echo "--- Zapret Module for Magisk ---"
+    echo "--- Zapret Pocket ---"
     echo "! Current strategy: $CURRENTSTRATEGY"
     if [ "$UPDATEONSTART" = "1" ]; then
         echo "! Update on start enabled"

--- a/module/update.sh
+++ b/module/update.sh
@@ -16,8 +16,8 @@ CUSTOMLINKREESTR=$(cat "$MODPATH/config/reestr-link" 2>/dev/null || echo "https:
 
 PREDEFINED_LIST_FILES="reestr.txt default.txt google.txt"
 PREDEFINED_IPSET_FILES="ipset-v4.txt ipset-v6.txt"
-ZAPRETLISTSDEFAULTLINK="https://raw.githubusercontent.com/sevcator/zapret-magisk/refs/heads/main/module/list/"
-ZAPRETIPSETSDEFAULTLINK="https://raw.githubusercontent.com/sevcator/zapret-magisk/refs/heads/main/module/ipset/"
+ZAPRETLISTSDEFAULTLINK="https://raw.githubusercontent.com/sevcator/zapret-pocket/refs/heads/main/module/list/"
+ZAPRETIPSETSDEFAULTLINK="https://raw.githubusercontent.com/sevcator/zapret-pocket/refs/heads/main/module/ipset/"
 IGNORE_FILES="custom.txt exclude.txt"
 get_overwrite_url() {
     file="$1"

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -853,7 +853,7 @@
 </div>
 <div class="credits-section">
 <p class="credits-text">
-       zapret module by
+       Zapret Pocket by
        <a href="javascript:void(0)" id="sevcator-link" target="_blank">
         sevcator
        </a>

--- a/update.json
+++ b/update.json
@@ -1,6 +1,6 @@
 {
   "version": "20.1",
   "versionCode": "201",
-  "zipUrl": "https://github.com/sevcator/zapret-magisk/releases/download/20.1/zapret-Magisk.zip",
-  "changelog": "https://raw.githubusercontent.com/sevcator/zapret-magisk/main/CHANGELOG.md"
+  "zipUrl": "https://github.com/sevcator/zapret-pocket/releases/download/20.1/zapret-pocket.zip",
+  "changelog": "https://raw.githubusercontent.com/sevcator/zapret-pocket/main/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- rename project name to **Zapret Pocket** in docs and scripts
- update workflow job and step names to build the module
- label the release packaging step simply as **Build Module**

## Testing
- `ruby -ryaml -e "YAML.load_file('.github/workflows/build_module.yml'); puts 'YAML OK'"`
- `bash -n module/update.sh`
- `bash -n module/system/bin/zapret`
- `yamllint .github/workflows/build_module.yml` *(fails: command not found; `pip install yamllint` fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afd3761b408331845137a14506d111