### PR TITLE
Disable DNSCrypt when IPv6 is enabled

### DIFF
--- a/module/system/bin/zapret
+++ b/module/system/bin/zapret
@@ -96,9 +96,6 @@ restart_service() {
 
 setup() {
     mkdir -p "$MODPATH/config"
-    DNSCRYPTENABLE="0"
-    CLOAKINGUPDATE="0"
-    BLOCKEDUPDATE="0"
     UPDATEONSTART="0"
     BYPASSCALLS="0"
     echo "! If the selection is anything other than \"Y\" or \"Yes\", it is considered a negative choice"
@@ -112,7 +109,10 @@ setup() {
     echo -n "- Enable IPv6? "
     read response
     case "$(echo "$response" | tr A-Z a-z)" in
-        y|yes) echo "- Enabled"; IPV6ENABLE="1" ;;
+        y|yes)
+            echo "- Enabled"
+            IPV6ENABLE="1"
+        ;;
     esac
     
     echo -n "- Enable Network Tweaks? "
@@ -126,12 +126,14 @@ setup() {
     case "$(echo "$response" | tr A-Z a-z)" in
         y|yes) echo "- Enabled"; BYPASSCALLS="1" ;;
     esac
-    
-    echo -n "- Enable DNSCrypt? "
-    read response
-    case "$(echo "$response" | tr A-Z a-z)" in
-        y|yes) echo "- Enabled"; DNSCRYPTENABLE="1" ;;
-    esac
+
+    if [ "$IPV6ENABLE" != "1" ]; then
+        echo -n "- Enable DNSCrypt? "
+        read response
+        case "$(echo "$response" | tr A-Z a-z)" in
+            y|yes) echo "- Enabled"; DNSCRYPTENABLE="1" ;;
+        esac
+    fi
 
     echo "- Available strategies:"
     find "$MODPATH/strategy" -type f -name "*.sh" 2>/dev/null | while IFS= read -r file; do
@@ -183,7 +185,7 @@ setup() {
         esac
     fi
     
-    if [ "$DNSCRYPTENABLE" = "1" ]; then
+    if [ "$IPV6ENABLE" != "1" ] && [ "$DNSCRYPTENABLE" = "1" ]; then
         echo -n "- Auto-update cloaking rules for DNSCrypt? "
         read resp
         case "$(echo "$resp" | tr A-Z a-z)" in

--- a/module/update.sh
+++ b/module/update.sh
@@ -6,6 +6,7 @@ WGETCMD=$(cat "$MODPATH/wgetpath" 2>/dev/null || echo "wget")
 DNSCRYPTLISTSDIR="$MODPATH/dnscrypt"
 ZAPRETLISTSDIR="$MODPATH/list"
 ZAPRETIPSETSDIR="$MODPATH/ipset"
+IPV6ENABLE=$(cat "$MODPATH/config/ipv6-enable" 2>/dev/null || echo "0")
 CLOAKINGUPDATE=$(cat "$MODPATH/config/dnscrypt-cloaking-rules-update" 2>/dev/null || echo "0")
 BLOCKEDUPDATE=$(cat "$MODPATH/config/dnscrypt-blocked-names-update" 2>/dev/null || echo "0")
 DNSCRYPTFILES_cloaking_rules=$(cat "$MODPATH/config/dnscrypt-cloaking-rules-link" 2>/dev/null || echo "https://raw.githubusercontent.com/sevcator/dnscrypt-proxy-stuff/refs/heads/main/cloaking-rules.txt")
@@ -106,14 +107,18 @@ update_dir() {
     done
 }
 
-. "$MODPATH/dnscrypt/custom-cloaking-rules.sh" disappend > /dev/null 2>&1 &
-sleep 2
+if [ "$IPV6ENABLE" != "1" ]; then
+    . "$MODPATH/dnscrypt/custom-cloaking-rules.sh" disappend > /dev/null 2>&1 &
+    sleep 2
+fi
 
 update_dir "$ZAPRETLISTSDIR" "$ZAPRETLISTSDEFAULTLINK" "$PREDEFINED_LIST_FILES"
 update_dir "$ZAPRETIPSETSDIR" "$ZAPRETIPSETSDEFAULTLINK" "$PREDEFINED_IPSET_FILES"
 
-[ "$CLOAKINGUPDATE" = "1" ] && update_file "$DNSCRYPTLISTSDIR/cloaking-rules.txt" "$DNSCRYPTFILES_cloaking_rules"
-[ "$BLOCKEDUPDATE" = "1" ] && update_file "$DNSCRYPTLISTSDIR/blocked-names.txt" "$DNSCRYPTFILES_blocked_names"
+[ "$IPV6ENABLE" != "1" ] && [ "$CLOAKINGUPDATE" = "1" ] && update_file "$DNSCRYPTLISTSDIR/cloaking-rules.txt" "$DNSCRYPTFILES_cloaking_rules"
+[ "$IPV6ENABLE" != "1" ] && [ "$BLOCKEDUPDATE" = "1" ] && update_file "$DNSCRYPTLISTSDIR/blocked-names.txt" "$DNSCRYPTFILES_blocked_names"
 
-. "$MODPATH/dnscrypt/custom-cloaking-rules.sh" append > /dev/null 2>&1 &
-sleep 2
+if [ "$IPV6ENABLE" != "1" ]; then
+    . "$MODPATH/dnscrypt/custom-cloaking-rules.sh" append > /dev/null 2>&1 &
+    sleep 2
+fi

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -1446,6 +1446,7 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                 const toggleUpdateOnStart = document.getElementById('toggle-update-on-start');
                 const toggleCloakingUpdate = document.getElementById('toggle-cloaking-update');
                 const toggleBlockedNamesUpdate = document.getElementById('toggle-blocked-names-update');
+                const toggleIpv6 = document.getElementById('toggle-ipv6');
                 const logsContentZapret = document.getElementById('logs-content-zapret');
                 const logsContentDnscrypt = document.getElementById('logs-content-dnscrypt');
                 const toggleTheme = document.getElementById('toggle-theme');
@@ -1503,10 +1504,14 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                     return stdout.trim();
                 };
 
-                const updateDnscryptDependentFields = (dnscryptEnabled) => {
+                const updateDnscryptDependentFields = (dnscryptEnabled, ipv6Enabled) => {
                     const dnscryptDependentElements = document.querySelectorAll('.dnscrypt-dependent');
+
+                    toggleDnscrypt.disabled = ipv6Enabled;
+
+                    const enableElements = dnscryptEnabled && !ipv6Enabled;
                     dnscryptDependentElements.forEach(element => {
-                        if (dnscryptEnabled) {
+                        if (enableElements) {
                             element.classList.remove('disabled');
                             const input = element.querySelector('.text-input');
                             if (input) input.disabled = false;
@@ -1649,13 +1654,14 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                         
                         // Update toggles
                         const isDnscryptChecked = dnscryptEnabled === '1';
+                        const isIpv6Checked = ipv6Enable === '1';
                         toggleDnscrypt.checked = isDnscryptChecked;
                         toggleRulesRecheck.checked = rulesRecheck === '1';
                         toggleUpdateOnStart.checked = updateOnStart === '1' || updateOnStart === '';
                         toggleCloakingUpdate.checked = cloakingUpdate === '1';
                         toggleBlockedNamesUpdate.checked = blockedNamesUpdate === '1';
                         document.getElementById('toggle-bypass-calls').checked = bypassCalls === '1';
-                        document.getElementById('toggle-ipv6').checked = ipv6Enable === '1';
+                        toggleIpv6.checked = isIpv6Checked;
                         document.getElementById('toggle-network-tweaks').checked = networkTweaks === '1';
                         
                         // Update custom links
@@ -1666,7 +1672,7 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                         inputBlockedNames.value = blockedNamesLink;
                         
                         // Update DNSCrypt dependent fields
-                        updateDnscryptDependentFields(isDnscryptChecked);
+                        updateDnscryptDependentFields(isDnscryptChecked, isIpv6Checked);
 
                         // Update file contents (only if not dirty)
                         Object.keys(fileContents).forEach(path => {
@@ -1760,14 +1766,17 @@ btnPrimary.addEventListener('click', async () => {
                 
                 // Setup all toggles
                 setupToggle(toggleDnscrypt, 'dnscrypt-enable', () => {
-                    updateDnscryptDependentFields(toggleDnscrypt.checked);
+                    updateDnscryptDependentFields(toggleDnscrypt.checked, toggleIpv6.checked);
                 });
                 setupToggle(toggleRulesRecheck, 'dnscrypt-rules-fix');
                 setupToggle(toggleUpdateOnStart, 'update-on-start');
                 setupToggle(toggleCloakingUpdate, 'dnscrypt-cloaking-rules-update');
                 setupToggle(toggleBlockedNamesUpdate, 'dnscrypt-blocked-names-update');
                 setupToggle(document.getElementById('toggle-bypass-calls'), 'bypass-calls');
-                setupToggle(document.getElementById('toggle-ipv6'), 'ipv6-enable');
+                setupToggle(toggleIpv6, 'ipv6-enable', () => {
+                    const ipv6Enabled = toggleIpv6.checked;
+                    updateDnscryptDependentFields(toggleDnscrypt.checked, ipv6Enabled);
+                });
                 setupToggle(document.getElementById('toggle-network-tweaks'), 'network-tweaks');
 
                 // Custom links setup helper

--- a/module/zapret-main.sh
+++ b/module/zapret-main.sh
@@ -1,6 +1,7 @@
 #!/system/bin/sh
 MODPATH="/data/adb/modules/zapret"
 UPDATEONSTART=$(cat "$MODPATH/config/update-on-start" 2>/dev/null || echo "1")
+IPV6ENABLE=$(cat "$MODPATH/config/ipv6-enable" 2>/dev/null || echo "0")
 touch "$MODPATH/dnscrypt/cloaking-rules.txt"
 touch "$MODPATH/dnscrypt/custom-cloaking-rules.txt"
 touch "$MODPATH/dnscrypt/blocked-names.txt"
@@ -19,7 +20,7 @@ if [ "$UPDATEONSTART" = "1" ]; then
     . "$MODPATH/update.sh" > /dev/null 2>&1
     sleep 2
 fi
-if [ "$(cat "$MODPATH/config/dnscrypt-enable" 2>/dev/null)" = "1" ]; then
+if [ "$IPV6ENABLE" != "1" ] && [ "$(cat "$MODPATH/config/dnscrypt-enable" 2>/dev/null)" = "1" ]; then
     nohup sh "$MODPATH/dnscrypt/dnscrypt.sh" > /dev/null 2>&1 &
 fi
 nohup sh "$MODPATH/zapret/zapret.sh" > /dev/null 2>&1 &


### PR DESCRIPTION
## Summary
- Disable DNSCrypt options in the web UI when IPv6 is enabled without overwriting saved settings
- Skip DNSCrypt setup and updates when IPv6 is active
- Prevent DNSCrypt from starting while IPv6 is turned on

## Testing
- `sh -n module/system/bin/zapret`
- `sh -n module/update.sh`
- `sh -n module/zapret-main.sh`


------
https://chatgpt.com/codex/tasks/task_e_68afdfca6b308331866ef4eda339a2bc