### PR TITLE
Ignore DNSCrypt when IPv6 enabled

### DIFF
--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -1667,11 +1667,12 @@ async function waitForPidChange(oldPid, timeout = 5000) {
                         });
 
                         renderZapretLogs(currentZapretLogText);
-                        renderDnscryptLogs(currentDnscryptLogText, isDnscryptChecked, dnscryptStatus === 'Running');
+                        const dnscryptActive = isDnscryptChecked && !isIpv6Checked;
+                        renderDnscryptLogs(currentDnscryptLogText, dnscryptActive, dnscryptStatus === 'Running');
 
                         const statusCard = statusNfqws.closest('.card');
                         const isNfqwsRunning = nfqwsStatus === 'Running';
-                        const isDnscryptOk = !isDnscryptChecked || (isDnscryptChecked && dnscryptStatus === 'Running');
+                        const isDnscryptOk = !dnscryptActive || (dnscryptActive && dnscryptStatus === 'Running');
 
                         if (isNfqwsRunning && isDnscryptOk) {
                             statusCard.classList.add('all-running');


### PR DESCRIPTION
## Summary
- Ignore DNSCrypt status when IPv6 is active so Zapret shows running outline

## Testing
- `npm test` *(fails: package.json missing)*
- `npx prettier --check module/webroot/index.html` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68affa4745f08331b341a40319aaf904