### PR TITLE
feat: add retry logic for update script

### DIFF
--- a/module/update.sh
+++ b/module/update.sh
@@ -40,18 +40,20 @@ update_file() {
     name=$(basename "$file")
 
     tmp_file="${file}.tmp"
-    if $WGETCMD -q -O "$tmp_file" "$url" >/dev/null 2>&1; then
-        if [ ! -f "$file" ] || ! cmp -s "$tmp_file" "$file"; then
-            mv "$tmp_file" "$file"
-            echo "[ $name ] Downloaded"
-        else
-            rm -f "$tmp_file"
-            echo "[ $name ] Unchanged"
+    for _ in 1 2 3 4 5; do
+        if $WGETCMD -q -O "$tmp_file" "$url" >/dev/null 2>&1; then
+            if [ ! -f "$file" ] || ! cmp -s "$tmp_file" "$file"; then
+                mv "$tmp_file" "$file"
+                echo "[ $name ] Downloaded"
+            else
+                rm -f "$tmp_file"
+                echo "[ $name ] Unchanged"
+            fi
+            return
         fi
-    else
-        rm -f "$tmp_file"
-        echo "[ $name ] Failed"
-    fi
+    done
+    rm -f "$tmp_file"
+    echo "[ $name ] Failed"
 }
 
 update_dir() {


### PR DESCRIPTION
## Summary
- retry downloads up to 5 times in update script

## Testing
- `sh -n module/update.sh`
- `shellcheck module/update.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00882b59083318032ac0ffdb066bc