### PR TITLE
Reduce spacing between controls

### DIFF
--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -204,27 +204,27 @@
         .settings {
             display: flex;
             flex-direction: column;
-            gap: 6px;
+            gap: 4px;
         }
         .setting-item {
             display: flex;
-            justify-content: space-between;
             align-items: center;
+            gap: 8px;
             min-height: 36px;
         }
         .setting-item > label {
             flex-shrink: 0;
-            margin-right: 8px;
             font-weight: 500;
         }
         .setting-item.stacked {
             flex-direction: column;
             align-items: stretch;
             justify-content: flex-start;
+            gap: 4px;
         }
         .setting-item.stacked > label {
             margin-right: 0;
-            margin-bottom: 4px;
+            margin-bottom: 0;
         }
         select {
             background-color: var(--bg-input);


### PR DESCRIPTION
## Summary
- Decrease vertical spacing in settings section
- Pull switches closer to their labels for a tighter layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b039b52708833194ada2e126a350af