### PR TITLE
Simplify import_strategy function

### DIFF
--- a/module/system/bin/zapret
+++ b/module/system/bin/zapret
@@ -283,23 +283,17 @@ search() {
 
 import_strategy() {
     url="$1"
-    [ -z "$url" ] && echo "! No URL provided" && return 1
+    [ -n "$url" ] || { echo "! No URL provided"; return 1; }
 
     mkdir -p "$MODPATH/strategy"
 
-    file_part="${url##*/}"
-    file_part="${file_part%%\?*}"
-    if [ "${file_part##*.}" = "sh" ] && [ -n "$file_part" ]; then
-        filename="$file_part"
-    else
-        filename="downloaded-$(date +%Y%m%d%H%M%S).sh"
-    fi
+    filename="${url%%\?*}"
+    filename="${filename##*/}"
+    [ "${filename##*.}" = "sh" ] || filename="downloaded-$(date +%Y%m%d%H%M%S).sh"
 
-    wget_cmd="${WGETPATH:-wget}"
-    if "$wget_cmd" -q -O "$MODPATH/strategy/$filename" "$url"; then
+    if "$WGETPATH" -q -O "$MODPATH/strategy/$filename" "$url"; then
         chmod +x "$MODPATH/strategy/$filename"
         echo "- Saved as $filename"
-        return 0
     else
         echo "! Download failed"
         return 1


### PR DESCRIPTION
## Summary
- streamline import_strategy: consolidate filename derivation and download invocation
- use explicit WGETPATH without default fallback

## Testing
- `bash -n module/system/bin/zapret`
- `shellcheck module/system/bin/zapret` *(fails: command not found; apt repositories return 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b076dd6890833185bba22933e172ca