### PR TITLE
Fix workflow YAML syntax issues

### DIFF
--- a/.github/workflows/build_module.yml
+++ b/.github/workflows/build_module.yml
@@ -202,55 +202,55 @@ jobs:
           name: nfqws-x86_64
           path: module
 
-        - name: Rename nfqws to nfqws-x86_x64
-          run: |
-            mv module/nfqws module/zapret/nfqws-x86_x64
+      - name: Rename nfqws to nfqws-x86_64
+        run: |
+          mv module/nfqws module/zapret/nfqws-x86_64
 
-        - name: Download curl armeabi-v7a
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-armeabi-v7a
-            path: module
+      - name: Download curl armeabi-v7a
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-armeabi-v7a
+          path: module
 
-        - name: Rename curl to curl-arm
-          run: |
-            mv module/curl module/curl-arm
+      - name: Rename curl to curl-arm
+        run: |
+          mv module/curl module/curl-arm
 
-        - name: Download curl arm64-v8a
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-arm64-v8a
-            path: module
+      - name: Download curl arm64-v8a
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-arm64-v8a
+          path: module
 
-        - name: Rename curl to curl-aarch64
-          run: |
-            mv module/curl module/curl-aarch64
+      - name: Rename curl to curl-aarch64
+        run: |
+          mv module/curl module/curl-aarch64
 
-        - name: Download curl x86
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-x86
-            path: module
+      - name: Download curl x86
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-x86
+          path: module
 
-        - name: Rename curl to curl-x86
-          run: |
-            mv module/curl module/curl-x86
+      - name: Rename curl to curl-x86
+        run: |
+          mv module/curl module/curl-x86
 
-        - name: Download curl x86_64
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-x86_64
-            path: module
+      - name: Download curl x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-x86_64
+          path: module
 
-        - name: Rename curl to curl-x86_64
-          run: |
-            mv module/curl module/curl-x86_64
+      - name: Rename curl to curl-x86_64
+        run: |
+          mv module/curl module/curl-x86_64
 
-        - name: Download dnscrypt-proxy
-          uses: actions/download-artifact@v4
-          with:
-            name: dnscrypt-proxy
-            path: module/dnscrypt
+      - name: Download dnscrypt-proxy
+        uses: actions/download-artifact@v4
+        with:
+          name: dnscrypt-proxy
+          path: module/dnscrypt
 
       - name: Build Module
         run: |

--- a/.github/workflows/test-build-module.yml
+++ b/.github/workflows/test-build-module.yml
@@ -202,55 +202,55 @@ jobs:
           name: nfqws-x86_64
           path: module
 
-        - name: Rename nfqws to nfqws-x86_x64
-          run: |
-            mv module/nfqws module/zapret/nfqws-x86_x64
+      - name: Rename nfqws to nfqws-x86_64
+        run: |
+          mv module/nfqws module/zapret/nfqws-x86_64
 
-        - name: Download curl armeabi-v7a
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-armeabi-v7a
-            path: module
+      - name: Download curl armeabi-v7a
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-armeabi-v7a
+          path: module
 
-        - name: Rename curl to curl-arm
-          run: |
-            mv module/curl module/curl-arm
+      - name: Rename curl to curl-arm
+        run: |
+          mv module/curl module/curl-arm
 
-        - name: Download curl arm64-v8a
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-arm64-v8a
-            path: module
+      - name: Download curl arm64-v8a
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-arm64-v8a
+          path: module
 
-        - name: Rename curl to curl-aarch64
-          run: |
-            mv module/curl module/curl-aarch64
+      - name: Rename curl to curl-aarch64
+        run: |
+          mv module/curl module/curl-aarch64
 
-        - name: Download curl x86
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-x86
-            path: module
+      - name: Download curl x86
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-x86
+          path: module
 
-        - name: Rename curl to curl-x86
-          run: |
-            mv module/curl module/curl-x86
+      - name: Rename curl to curl-x86
+        run: |
+          mv module/curl module/curl-x86
 
-        - name: Download curl x86_64
-          uses: actions/download-artifact@v4
-          with:
-            name: curl-x86_64
-            path: module
+      - name: Download curl x86_64
+        uses: actions/download-artifact@v4
+        with:
+          name: curl-x86_64
+          path: module
 
-        - name: Rename curl to curl-x86_64
-          run: |
-            mv module/curl module/curl-x86_64
+      - name: Rename curl to curl-x86_64
+        run: |
+          mv module/curl module/curl-x86_64
 
-        - name: Download dnscrypt-proxy
-          uses: actions/download-artifact@v4
-          with:
-            name: dnscrypt-proxy
-            path: module/dnscrypt
+      - name: Download dnscrypt-proxy
+        uses: actions/download-artifact@v4
+        with:
+          name: dnscrypt-proxy
+          path: module/dnscrypt
 
       - name: Build Module
         run: |


### PR DESCRIPTION
## Summary
- fix indentation for x86_64 artifact steps in workflows
- correct nfqws x86_64 rename and align curl artifact handling

## Testing
- ⚠️ `yamllint .github/workflows/build_module.yml .github/workflows/test-build-module.yml` (yamllint not installed; pip install failed: 403)
- ⚠️ `npx --yes actionlint .github/workflows/build_module.yml` (403 Forbidden when fetching actionlint)


------
https://chatgpt.com/codex/tasks/task_e_68bbef28655883318317ead5307c989b