### PR TITLE
Fix curl build workflow

### DIFF
--- a/.github/workflows/build_module.yml
+++ b/.github/workflows/build_module.yml
@@ -131,16 +131,18 @@ jobs:
         run: |
           export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
           export API=21
-          export CC="$TOOLCHAIN/bin/clang --target=$TARGET$API"
-          export AR=$TOOLCHAIN/bin/llvm-ar
+          export PATH=$TOOLCHAIN/bin:$PATH
+          export CC=${TARGET}${API}-clang
+          export CXX=${TARGET}${API}-clang++
+          export AR=llvm-ar
           export AS=$CC
-          export LD=$TOOLCHAIN/bin/ld
-          export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
-          export STRIP=$TOOLCHAIN/bin/llvm-strip
+          export LD=ld.lld
+          export RANLIB=llvm-ranlib
+          export STRIP=llvm-strip
 
           curl -sSL https://www.openssl.org/source/openssl-3.3.0.tar.gz | tar -xz
           cd openssl-3.3.0
-          ./Configure $OPENSSL_TARGET no-shared no-tests no-dso --prefix=$PWD/../openssl-out
+          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-dso --prefix=$PWD/../openssl-out
           make install_sw -j$(nproc)
           cd ..
 

--- a/.github/workflows/test-build-module.yml
+++ b/.github/workflows/test-build-module.yml
@@ -131,16 +131,18 @@ jobs:
         run: |
           export TOOLCHAIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64
           export API=21
-          export CC="$TOOLCHAIN/bin/clang --target=$TARGET$API"
-          export AR=$TOOLCHAIN/bin/llvm-ar
+          export PATH=$TOOLCHAIN/bin:$PATH
+          export CC=${TARGET}${API}-clang
+          export CXX=${TARGET}${API}-clang++
+          export AR=llvm-ar
           export AS=$CC
-          export LD=$TOOLCHAIN/bin/ld
-          export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
-          export STRIP=$TOOLCHAIN/bin/llvm-strip
+          export LD=ld.lld
+          export RANLIB=llvm-ranlib
+          export STRIP=llvm-strip
 
           curl -sSL https://www.openssl.org/source/openssl-3.3.0.tar.gz | tar -xz
           cd openssl-3.3.0
-          ./Configure $OPENSSL_TARGET no-shared no-tests no-dso --prefix=$PWD/../openssl-out
+          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-dso --prefix=$PWD/../openssl-out
           make install_sw -j$(nproc)
           cd ..
 


### PR DESCRIPTION
## Summary
- ensure curl build uses NDK clang wrappers and API flag

## Testing
- `yamllint .github/workflows/build_module.yml .github/workflows/test-build-module.yml` *(command not found)*
- `pip install --user yamllint` *(failed: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf66ea7a08331be49fab078ccf327