### PR TITLE
Fix OpenSSL build race in Android curl workflow

### DIFF
--- a/.github/workflows/build_module.yml
+++ b/.github/workflows/build_module.yml
@@ -143,7 +143,8 @@ jobs:
           curl -sSL https://www.openssl.org/source/openssl-3.3.0.tar.gz | tar -xz
           cd openssl-3.3.0
           ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-dso --prefix=$PWD/../openssl-out
-          make install_sw -j$(nproc)
+          make -j$(nproc)
+          make install_sw
           cd ..
 
           curl -sSL https://curl.se/download/curl-8.7.1.tar.xz | tar -xJ


### PR DESCRIPTION
## Summary
- Avoid parallel `make install_sw` when building OpenSSL for curl

## Testing
- `yamllint .github/workflows/build_module.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfe0484948331bfc005ff5e351fe3