### PR TITLE
fix: avoid OpenSSL apps in curl build

### DIFF
--- a/.github/workflows/build_module.yml
+++ b/.github/workflows/build_module.yml
@@ -142,9 +142,8 @@ jobs:
 
           curl -sSL https://www.openssl.org/source/openssl-3.3.0.tar.gz | tar -xz
           cd openssl-3.3.0
-          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-dso --prefix=$PWD/../openssl-out
-          make -j$(nproc)
-          make install_sw
+          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-apps no-dso --prefix=$PWD/../openssl-out
+          make install_sw -j$(nproc)
           cd ..
 
           curl -sSL https://curl.se/download/curl-8.7.1.tar.xz | tar -xJ

--- a/.github/workflows/test-build-module.yml
+++ b/.github/workflows/test-build-module.yml
@@ -142,7 +142,7 @@ jobs:
 
           curl -sSL https://www.openssl.org/source/openssl-3.3.0.tar.gz | tar -xz
           cd openssl-3.3.0
-          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-dso --prefix=$PWD/../openssl-out
+          ./Configure $OPENSSL_TARGET -D__ANDROID_API__=$API no-shared no-tests no-apps no-dso --prefix=$PWD/../openssl-out
           make install_sw -j$(nproc)
           cd ..
 


### PR DESCRIPTION
## Summary
- skip building OpenSSL apps when cross compiling for curl
- build and install OpenSSL in a single step to avoid race conditions

## Testing
- `yamllint .github/workflows/build_module.yml .github/workflows/test-build-module.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bbff79d19c8331b0d9d59b3219e0c0