### PR TITLE
chore: emit VERSION as v<TAG> in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,13 +265,13 @@ jobs:
         run: |
           # Generate timestamp in Moscow time (UTC+3)
           BUILD_TIME=$(TZ='Europe/Moscow' date '+%d-%m-%y %H:%M:%S')
-          VERSION="build at ${BUILD_TIME}"
 
           RELEASE_COUNT="$(gh api "repos/${REPO}/releases" --paginate --jq 'length' | awk '{s+=$1} END {print s+0}')"
           VERSION_CODE=$((RELEASE_COUNT + 1))
 
-          RELEASE_NAME="${BUILD_TIME}"
           TAG="${VERSION_CODE}"
+          VERSION="v${TAG}"
+          RELEASE_NAME="${BUILD_TIME}"
 
           # Fetch repo description from GitHub API
           DESCRIPTION="$(gh api "repos/${REPO}" --jq '.description // "Zapret module"')"


### PR DESCRIPTION
### Motivation
- Сменить читаемую метку версии в CI с временной строки на формат тега `v<TAG>`, чтобы отображаемая версия соответствовала номеру релиза/тега.

### Description
- В `.github/workflows/build.yml` в шаге `Determine version info` `VERSION` теперь устанавливается как `v${TAG}` (где `TAG` равен `VERSION_CODE`) вместо `build at ${BUILD_TIME}`, при этом логика вычисления `TAG`/`VERSION_CODE` сохранена.

### Testing
- Автоматически применил патч и проверил изменения с помощью `git diff` и `git commit`, оба шага прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b05d22188331a506827e7e8d8c6d)