### PR TITLE
Ensure download_file only reports success after a successful mv and clean up temp files

### DIFF
--- a/module/common.sh
+++ b/module/common.sh
@@ -634,14 +634,20 @@ download_file() {
     downloader="$(resolve_downloader 2>/dev/null || true)"
     if [ -n "$downloader" ]; then
         if download_with_curl "$downloader" "$url" "$tmp"; then
-            mv "$tmp" "$output"
-            return 0
+            if mv "$tmp" "$output"; then
+                return 0
+            fi
+            rm -f "$tmp"
+            debug_log "failed to move downloaded file into place: $tmp -> $output"
         fi
         debug_log "curl download failed for: $url"
 
         if [ -n "$alt_url" ] && download_with_curl "$downloader" "$alt_url" "$tmp"; then
-            mv "$tmp" "$output"
-            return 0
+            if mv "$tmp" "$output"; then
+                return 0
+            fi
+            rm -f "$tmp"
+            debug_log "failed to move downloaded alternate file into place: $tmp -> $output"
         fi
         [ -n "$alt_url" ] && debug_log "curl alternate download failed for: $alt_url"
     fi
@@ -649,14 +655,20 @@ download_file() {
     downloader="$(resolve_wget 2>/dev/null || true)"
     if [ -n "$downloader" ]; then
         if download_with_wget "$downloader" "$url" "$tmp"; then
-            mv "$tmp" "$output"
-            return 0
+            if mv "$tmp" "$output"; then
+                return 0
+            fi
+            rm -f "$tmp"
+            debug_log "failed to move downloaded file into place: $tmp -> $output"
         fi
         debug_log "wget download failed for: $url"
 
         if [ -n "$alt_url" ] && download_with_wget "$downloader" "$alt_url" "$tmp"; then
-            mv "$tmp" "$output"
-            return 0
+            if mv "$tmp" "$output"; then
+                return 0
+            fi
+            rm -f "$tmp"
+            debug_log "failed to move downloaded alternate file into place: $tmp -> $output"
         fi
         [ -n "$alt_url" ] && debug_log "wget alternate download failed for: $alt_url"
     fi


### PR DESCRIPTION
### Motivation
- Prevent false-positive download success when `mv "$tmp" "$output"` fails which caused callers to believe files like `suite.json` existed when they did not.
- Make `download_file()` robust across all downloader branches (curl/wget and alternate URLs) so partial failures are cleaned up and logged.

### Description
- Updated `download_file()` in `module/common.sh` to check the exit status of `mv "$tmp" "$output"` and only return success after the move succeeds.
- Added `rm -f "$tmp"` and `debug_log` messages when the move fails to ensure temporary files are removed and failures are recorded.
- Applied the same move-check, cleanup, and logging logic for curl primary, curl alternate, wget primary, and wget alternate paths.
- Kept the final `rm -f "$tmp"` and explicit failure return so callers get a proper non-zero return on full download failure.

### Testing
- Ran shell syntax check with `sh -n module/common.sh` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cadb1f24833188e59cc8f98f3d67)